### PR TITLE
Fix license identifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ mod_name=Tag Tooltips
 mod_id=tagtooltips
 group=jagm.tagtooltips
 mod_author=Jagm
-license=CC BY-NC-SA 4.0
+license=CC-BY-NC-SA 4.0
 credits=
 description=Hold semicolon to view item tags.
 


### PR DESCRIPTION
It's supposed to have a dash there. See https://spdx.org/licenses/CC-BY-NC-SA-4.0.html